### PR TITLE
Refactors subscription manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 project(clio)
 cmake_minimum_required(VERSION 3.16)
-set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wno-narrowing")
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,8 @@ target_sources(clio PRIVATE
   ## ETL
   src/etl/ETLSource.cpp
   src/etl/ReportingETL.cpp
-  ## Server
-  src/webserver/SubscriptionManager.cpp
+  ## Subscriptions
+  src/subscriptions/SubscriptionManager.cpp
   ## RPC
   src/rpc/RPC.cpp
   src/rpc/RPCHelpers.cpp

--- a/src/etl/ETLSource.h
+++ b/src/etl/ETLSource.h
@@ -8,7 +8,7 @@
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
 #include <backend/BackendInterface.h>
-#include <webserver/SubscriptionManager.h>
+#include <subscriptions/SubscriptionManager.h>
 
 #include "org/xrpl/rpc/v1/xrp_ledger.grpc.pb.h"
 #include <etl/ETLHelpers.h>

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <string>
 #include <variant>
-#include <webserver/SubscriptionManager.h>
+#include <subscriptions/SubscriptionManager.h>
 
 namespace detail {
 /// Convenience function for printing out basic ledger info

--- a/src/etl/ReportingETL.h
+++ b/src/etl/ReportingETL.h
@@ -8,7 +8,7 @@
 #include <boost/beast/websocket.hpp>
 #include <backend/BackendInterface.h>
 #include <etl/ETLSource.h>
-#include <webserver/SubscriptionManager.h>
+#include <subscriptions/SubscriptionManager.h>
 
 #include "org/xrpl/rpc/v1/xrp_ledger.grpc.pb.h"
 #include <grpcpp/grpcpp.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,7 @@ main(int argc, char* argv[])
 
     // Manages clients subscribed to streams
     std::shared_ptr<SubscriptionManager> subscriptions{
-        SubscriptionManager::make_SubscriptionManager(backend, ioc)};
+        SubscriptionManager::make_SubscriptionManager(backend)};
 
     // Tracks which ledgers have been validated by the
     // network

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,7 @@ main(int argc, char* argv[])
 
     // Manages clients subscribed to streams
     std::shared_ptr<SubscriptionManager> subscriptions{
-        SubscriptionManager::make_SubscriptionManager(backend)};
+        SubscriptionManager::make_SubscriptionManager(backend, ioc)};
 
     // Tracks which ledgers have been validated by the
     // network

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,7 @@ main(int argc, char* argv[])
 
     // Manages clients subscribed to streams
     std::shared_ptr<SubscriptionManager> subscriptions{
-        SubscriptionManager::make_SubscriptionManager(backend)};
+        SubscriptionManager::make_SubscriptionManager(*config, backend)};
 
     // Tracks which ledgers have been validated by the
     // network

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -4,6 +4,8 @@
 
 namespace RPC {
 
+using boost::json::value_to;
+
 Result
 doAccountTx(Context const& context)
 {

--- a/src/rpc/handlers/BookOffers.cpp
+++ b/src/rpc/handlers/BookOffers.cpp
@@ -16,20 +16,9 @@ namespace RPC {
 
 
 Result
-doValidatedBookOffers(Context const& context)
-{
-    
-}
-
-Result
 doBookOffers(Context const& context)
 {
     auto request = context.params;
-    if (!request.contains("ledger_index") 
-      || request.at("ledger_index") == "validated")
-    {
-        return doValidatedBookOffers(context);
-    }
 
     boost::json::object response = {};
     auto v = ledgerInfoFromRequest(context);

--- a/src/rpc/handlers/BookOffers.cpp
+++ b/src/rpc/handlers/BookOffers.cpp
@@ -14,12 +14,24 @@
 
 namespace RPC {
 
+
+Result
+doValidatedBookOffers(Context const& context)
+{
+    
+}
+
 Result
 doBookOffers(Context const& context)
 {
     auto request = context.params;
-    boost::json::object response = {};
+    if (!request.contains("ledger_index") 
+      || request.at("ledger_index") == "validated")
+    {
+        return doValidatedBookOffers(context);
+    }
 
+    boost::json::object response = {};
     auto v = ledgerInfoFromRequest(context);
     if (auto status = std::get_if<Status>(&v))
         return *status;

--- a/src/rpc/handlers/LedgerData.cpp
+++ b/src/rpc/handlers/LedgerData.cpp
@@ -20,6 +20,8 @@
 
 namespace RPC {
 
+using boost::json::value_to;
+
 Result
 doLedgerData(Context const& context)
 {

--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -13,6 +13,8 @@
 namespace RPC 
 {
 
+using boost::json::value_to;
+
 Result
 doLedgerEntry(Context const& context)
 {

--- a/src/rpc/handlers/Subscribe.cpp
+++ b/src/rpc/handlers/Subscribe.cpp
@@ -1,5 +1,5 @@
 #include <boost/json.hpp>
-#include <webserver/SubscriptionManager.h>
+#include <subscriptions/SubscriptionManager.h>
 #include <webserver/WsBase.h>
 
 #include <rpc/RPCHelpers.h>

--- a/src/rpc/handlers/Subscribe.cpp
+++ b/src/rpc/handlers/Subscribe.cpp
@@ -10,7 +10,9 @@ namespace RPC {
 static std::unordered_set<std::string> validCommonStreams{
     "ledger",
     "transactions",
-    "transactions_proposed"};
+    "transactions_proposed",
+    "validations",
+    "manifests"};
 
 Status
 validateStreams(boost::json::object const& request)
@@ -50,6 +52,10 @@ subscribeToStreams(
             manager.subTransactions(session);
         else if (s == "transactions_proposed")
             manager.subProposedTransactions(session);
+        else if (s == "validations")
+            manager.subValidation(session);
+        else if (s == "manifests")
+            manager.subManifest(session);
         else
             assert(false);
     }
@@ -74,6 +80,10 @@ unsubscribeToStreams(
             manager.unsubTransactions(session);
         else if (s == "transactions_proposed")
             manager.unsubProposedTransactions(session);
+        else if (s == "validations")
+            manager.unsubValidation(session);
+        else if (s == "manifests")
+            manager.unsubManifest(session);
         else
             assert(false);
     }

--- a/src/subscriptions/SubscriptionManager.cpp
+++ b/src/subscriptions/SubscriptionManager.cpp
@@ -7,18 +7,15 @@ Subscription::sendAll(std::string const& pubMsg)
 {
     for (auto it = subscribers_.begin(); it != subscribers_.end();)
     {
-        std::cout << "PUBLISHING TO SUBSCRIBER" << std::endl;
         auto& session = *it;
         if (session->dead())
         {
-            std::cout << "SESSION IS DEAD" << std::endl;
             it = subscribers_.erase(it);
         }
         else
         {
-            session->send(msg);
+            session->send(pubMsg);
             ++it;
-            std::cout << "DONE SENDING" << std::endl;
         }
     }
 }
@@ -26,11 +23,8 @@ Subscription::sendAll(std::string const& pubMsg)
 void
 Subscription::subscribe(std::shared_ptr<WsBase> const& session)
 {
-    std::cout << "SUBSCRIBING" << std::endl;
     boost::asio::post(strand_, [this, session](){
-        std::cout << "EMPLACING " << std::endl;
         subscribers_.emplace(session);
-        std::cout << "EMPLACED" << std::endl;
     });
 }
 
@@ -38,9 +32,7 @@ void
 Subscription::unsubscribe(std::shared_ptr<WsBase> const& session)
 {
     boost::asio::post(strand_, [this, session](){
-        std::cout << "ERASING" << std::endl;
         subscribers_.erase(session);
-        std::cout << "ERASED" << std::endl;
     });
 }
 
@@ -57,9 +49,6 @@ AccountSubscription::subscribe(
     std::shared_ptr<WsBase> const& session,
     ripple::AccountID const& account)
 {
-    if (strand_.running_in_this_thread())
-        return;
-
     boost::asio::post(strand_, [this, session, account](){
         subscribers_[account].emplace(session);
     });
@@ -70,9 +59,6 @@ AccountSubscription::unsubscribe(
     std::shared_ptr<WsBase> const& session,
     ripple::AccountID const& account)
 {
-    if (strand_.running_in_this_thread())
-        return;
-
     boost::asio::post(strand_, [this, session, account](){
         subscribers_[account].erase(session);
     });
@@ -83,9 +69,6 @@ AccountSubscription::publish(
     std::string const& message,
     ripple::AccountID const& account)
 {
-    if (strand_.running_in_this_thread())
-        return;
-
     boost::asio::post(strand_, [this, message, account]() {
         sendAll(message, account);
     });
@@ -134,9 +117,6 @@ BookSubscription::subscribe(
     std::shared_ptr<WsBase> const& session,
     ripple::Book const& book)
 {
-    if (strand_.running_in_this_thread())
-        return;
-
     boost::asio::post(strand_, [this, session, book](){
         subscribers_[book].emplace(session);
     });
@@ -147,9 +127,6 @@ BookSubscription::unsubscribe(
     std::shared_ptr<WsBase> const& session,
     ripple::Book const& book)
 {
-    if (strand_.running_in_this_thread())
-        return;
-
     boost::asio::post(strand_, [this, session, book](){
         subscribers_[book].erase(session);
     });
@@ -160,9 +137,6 @@ BookSubscription::publish(
     std::string const& message,
     ripple::Book const& book)
 {
-    if (strand_.running_in_this_thread())
-        return;
-
     boost::asio::post(strand_, [this, message, book](){
         sendAll(message, book);
     });

--- a/src/subscriptions/SubscriptionManager.h
+++ b/src/subscriptions/SubscriptionManager.h
@@ -11,6 +11,9 @@ class Subscription
     boost::asio::io_context::strand strand_;
     std::unordered_set<std::shared_ptr<WsBase>> subscribers_ = {};
 
+    void
+    sendAll(std::string const& pubMsg);
+
 public:
     static std::unique_ptr<Subscription>
     make_Subscription(boost::asio::io_context& ioc) {

--- a/src/webserver/Listener.h
+++ b/src/webserver/Listener.h
@@ -8,7 +8,7 @@
 #include <webserver/PlainWsSession.h>
 #include <webserver/SslHttpSession.h>
 #include <webserver/SslWsSession.h>
-#include <webserver/SubscriptionManager.h>
+#include <subscriptions/SubscriptionManager.h>
 
 #include <iostream>
 

--- a/src/webserver/SubscriptionManager.cpp
+++ b/src/webserver/SubscriptionManager.cpp
@@ -29,10 +29,10 @@ getLedgerPubMessage(
 boost::json::object
 SubscriptionManager::subLedger(std::shared_ptr<WsBase>& session)
 {
-    {
-        std::lock_guard lk(m_);
+    streams_[Ledgers].post([this, session](){
         streamSubscribers_[Ledgers].emplace(session);
-    }
+    });
+    
     auto ledgerRange = backend_->fetchLedgerRange();
     assert(ledgerRange);
     auto lgrInfo = backend_->fetchLedgerBySequence(ledgerRange->maxSequence);
@@ -54,22 +54,25 @@ SubscriptionManager::subLedger(std::shared_ptr<WsBase>& session)
 void
 SubscriptionManager::unsubLedger(std::shared_ptr<WsBase>& session)
 {
-    std::lock_guard lk(m_);
-    streamSubscribers_[Ledgers].erase(session);
+    streams_[Ledgers].post([this, session](){
+        streamSubscribers_[Ledgers].erase(session);
+    });
 }
 
 void
 SubscriptionManager::subTransactions(std::shared_ptr<WsBase>& session)
 {
-    std::lock_guard lk(m_);
-    streamSubscribers_[Transactions].emplace(session);
+    streams_[Transactions].post([this, session](){
+        streamSubscribers_[Transactions].emplace(session);
+    });
 }
 
 void
 SubscriptionManager::unsubTransactions(std::shared_ptr<WsBase>& session)
 {
-    std::lock_guard lk(m_);
-    streamSubscribers_[Transactions].erase(session);
+    streams_[Transactions].post([this, session](){
+        streamSubscribers_[Transactions].erase(session);
+    });
 }
 
 void
@@ -77,8 +80,9 @@ SubscriptionManager::subAccount(
     ripple::AccountID const& account,
     std::shared_ptr<WsBase>& session)
 {
-    std::lock_guard lk(m_);
-    accountSubscribers_[account].emplace(session);
+    strand_.post([this, session](){
+        accountSubscribers_[account].emplace(session);
+    });
 }
 
 void
@@ -86,8 +90,9 @@ SubscriptionManager::unsubAccount(
     ripple::AccountID const& account,
     std::shared_ptr<WsBase>& session)
 {
-    std::lock_guard lk(m_);
-    accountSubscribers_[account].erase(session);
+    strand_.post([this, session](){
+        accountSubscribers_[account].erase(session);
+    });
 }
 
 void
@@ -95,8 +100,9 @@ SubscriptionManager::subBook(
     ripple::Book const& book,
     std::shared_ptr<WsBase>& session)
 {
-    std::lock_guard lk(m_);
-    bookSubscribers_[book].emplace(session);
+    strand_.post([this, session](){
+        bookSubscribers_[book].emplace(session);
+    });
 }
 
 void
@@ -104,16 +110,17 @@ SubscriptionManager::unsubBook(
     ripple::Book const& book,
     std::shared_ptr<WsBase>& session)
 {
-    std::lock_guard lk(m_);
-    bookSubscribers_[book].erase(session);
+    strand_.post([this, &session](){
+        bookSubscribers_[book].erase(session);
+    });
 }
 
 void
 SubscriptionManager::sendAll(
     std::string const& pubMsg,
-    std::unordered_set<std::shared_ptr<WsBase>>& subs)
+    std::unordered_set<std::shared_ptr<WsBase>>& subs
+    )
 {
-    std::lock_guard lk(m_);
     for (auto it = subs.begin(); it != subs.end();)
     {
         auto& session = *it;
@@ -136,10 +143,12 @@ SubscriptionManager::pubLedger(
     std::string const& ledgerRange,
     std::uint32_t txnCount)
 {
-    sendAll(
-        boost::json::serialize(
-            getLedgerPubMessage(lgrInfo, fees, ledgerRange, txnCount)),
-        streamSubscribers_[Ledgers]);
+    streams_[Ledgers].post([this, lgrInfo, fees, ledgerRange, txnCount](){
+        sendAll(
+            boost::json::serialize(
+                getLedgerPubMessage(lgrInfo, fees, ledgerRange, txnCount)),
+            streamSubscribers_[Ledgers]);
+    });
 }
 
 void
@@ -181,13 +190,17 @@ SubscriptionManager::pubTransaction(
     }
 
     std::string pubMsg{boost::json::serialize(pubObj)};
-    sendAll(pubMsg, streamSubscribers_[Transactions]);
+    streams_[Transactions].post([this, pubMsg](){
+        sendAll(pubMsg, streamSubscribers_[Transactions]);
+    });
 
     auto journal = ripple::debugLog();
     auto accounts = meta->getAffectedAccounts(journal);
 
     for (ripple::AccountID const& account : accounts)
-        sendAll(pubMsg, accountSubscribers_[account]);
+        strand_.post([this, account, pubMsg](){
+            sendAll(pubMsg, accountSubscribers_[account]);
+        });
 
     std::unordered_set<ripple::Book> alreadySent;
 
@@ -222,7 +235,9 @@ SubscriptionManager::pubTransaction(
                         data->getFieldAmount(ripple::sfTakerPays).issue()};
                     if (!alreadySent.contains(book))
                     {
-                        sendAll(pubMsg, bookSubscribers_[book]);
+                        strand_.post([pubMsg, book, this](){
+                            sendAll(pubMsg, bookSubscribers_[book]);
+                        });
                         alreadySent.insert(book);
                     }
                 }
@@ -236,27 +251,35 @@ SubscriptionManager::forwardProposedTransaction(
     boost::json::object const& response)
 {
     std::string pubMsg{boost::json::serialize(response)};
-    sendAll(pubMsg, streamSubscribers_[TransactionsProposed]);
+    streams_[TransactionsProposed].post([account, pubMsg, this](){
+        sendAll(pubMsg, streamSubscribers_[TransactionsProposed]);
+    });
 
     auto transaction = response.at("transaction").as_object();
     auto accounts = RPC::getAccountsFromTransaction(transaction);
 
     for (ripple::AccountID const& account : accounts)
-        sendAll(pubMsg, accountProposedSubscribers_[account]);
+        strand_.post([account, pubMsg, this](){
+            sendAll(pubMsg, accountProposedSubscribers_[account]);
+        });
 }
 
 void 
 SubscriptionManager::forwardManifest(boost::json::object const& response)
 {
     std::string pubMsg{boost::json::serialize(response)};
-    sendAll(pubMsg, streamSubscribers_[Manifests]);
+    streams_[Manifests].post([m = std::move(pubMsg), this](){
+        sendAll(m, streamSubscribers_[Manifests]);
+    });
 }
 
 void 
 SubscriptionManager::forwardValidation(boost::json::object const& response)
 {
     std::string pubMsg{boost::json::serialize(response)};
-    sendAll(pubMsg, streamSubscribers_[Validations]);
+    streams_[Validations].post([m = std::move(pubMsg), this](){
+        sendAll(m, streamSubscribers_[Validations]);
+    });
 }
 
 void

--- a/src/webserver/SubscriptionManager.cpp
+++ b/src/webserver/SubscriptionManager.cpp
@@ -245,6 +245,20 @@ SubscriptionManager::forwardProposedTransaction(
         sendAll(pubMsg, accountProposedSubscribers_[account]);
 }
 
+void 
+SubscriptionManager::forwardManifest(boost::json::object const& response)
+{
+    std::string pubMsg{boost::json::serialize(response)};
+    sendAll(pubMsg, streamSubscribers_[Manifests]);
+}
+
+void 
+SubscriptionManager::forwardValidation(boost::json::object const& response)
+{
+    std::string pubMsg{boost::json::serialize(response)};
+    sendAll(pubMsg, streamSubscribers_[Validations]);
+}
+
 void
 SubscriptionManager::subProposedAccount(
     ripple::AccountID const& account,
@@ -252,6 +266,34 @@ SubscriptionManager::subProposedAccount(
 {
     std::lock_guard lk(m_);
     accountProposedSubscribers_[account].emplace(session);
+}
+
+void
+SubscriptionManager::subManifest(std::shared_ptr<WsBase>& session)
+{
+    std::lock_guard lk(m_);
+    streamSubscribers_[Manifests].emplace(session);
+}
+
+void
+SubscriptionManager::unsubManifest(std::shared_ptr<WsBase>& session)
+{
+    std::lock_guard lk(m_);
+    streamSubscribers_[Manifests].erase(session);
+}
+
+void
+SubscriptionManager::subValidation(std::shared_ptr<WsBase>& session)
+{
+    std::lock_guard lk(m_);
+    streamSubscribers_[Validations].emplace(session);
+}
+
+void
+SubscriptionManager::unsubValidation(std::shared_ptr<WsBase>& session)
+{
+    std::lock_guard lk(m_);
+    streamSubscribers_[Validations].emplace(session);
 }
 
 void

--- a/src/webserver/SubscriptionManager.h
+++ b/src/webserver/SubscriptionManager.h
@@ -14,6 +14,8 @@ class SubscriptionManager
         Ledgers,
         Transactions,
         TransactionsProposed,
+        Manifests,
+        Validations,
 
         finalEntry
     };
@@ -79,7 +81,25 @@ public:
     unsubBook(ripple::Book const& book, std::shared_ptr<WsBase>& session);
 
     void
+    subManifest(std::shared_ptr<WsBase>& session);
+
+    void
+    unsubManifest(std::shared_ptr<WsBase>& session);
+
+    void
+    subValidation(std::shared_ptr<WsBase>& session);
+
+    void
+    unsubValidation(std::shared_ptr<WsBase>& session);
+
+    void
     forwardProposedTransaction(boost::json::object const& response);
+
+    void
+    forwardManifest(boost::json::object const& response);
+
+    void
+    forwardValidation(boost::json::object const& response);
 
     void
     subProposedAccount(

--- a/src/webserver/SubscriptionManager.h
+++ b/src/webserver/SubscriptionManager.h
@@ -9,6 +9,7 @@ class WsBase;
 class SubscriptionManager
 {
     using subscriptions = std::unordered_set<std::shared_ptr<WsBase>>;
+    using strand = boost::asio::strand<boost::asio::executor>;
 
     enum SubscriptionType {
         Ledgers,
@@ -19,9 +20,11 @@ class SubscriptionManager
 
         finalEntry
     };
-    std::mutex m_;
     std::array<subscriptions, finalEntry> streamSubscribers_;
+    std::array<strand, finalEntry> streams_;
+    
     std::unordered_map<ripple::AccountID, subscriptions> accountSubscribers_;
+    strand strand_;
     std::unordered_map<ripple::AccountID, subscriptions>
         accountProposedSubscribers_;
     std::unordered_map<ripple::Book, subscriptions> bookSubscribers_;

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -119,7 +119,6 @@ public:
     sendNext()
     {
         std::lock_guard<std::mutex> lck(mtx_);
-        std::cout << "SENDING NEXT" << std::endl;
         derived().ws().async_write(
             boost::asio::buffer(messages_.front()),
             [shared = shared_from_this()](auto ec, size_t size) {
@@ -128,7 +127,6 @@ public:
                 size_t left = 0;
                 {
                     std::lock_guard<std::mutex> lck(shared->mtx_);
-                    std::cout << "IN SENDNEXT CALLBACK" << std::endl;
                     shared->messages_.pop();
                     left = shared->messages_.size();
                 }
@@ -138,15 +136,13 @@ public:
     }
 
     void
-    send(std::string&& msg)
+    enqueueMessage(std::string&& msg)
     {
         size_t left = 0;
         {
             std::lock_guard<std::mutex> lck(mtx_);
-            std::cout << "GRABBED SEND LOCK" << std::endl;
             messages_.push(std::move(msg));
             left = messages_.size();
-            std::cout << "ENDING SEND LOCK" << std::endl;
         }
         // if the queue was previously empty, start the send chain
         if (left == 1)
@@ -156,7 +152,7 @@ public:
     void
     send(std::string const& msg) override
     {
-        send({msg});
+        enqueueMessage(std::string(msg));
     }
 
     void


### PR DESCRIPTION
Refactors the Subscription forwarding to use `boost::asio::io_context` instead of one very large mutex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cjcobb23/clio/52)
<!-- Reviewable:end -->
