### PR TITLE
Build fix: specify template parameters

### DIFF
--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -141,7 +141,7 @@ makeAndExecuteAsyncWrite(
     B bind,
     std::string const& id)
 {
-    auto* cb = new WriteCallbackData(b, std::move(d), bind, id);
+    auto* cb = new WriteCallbackData<T,B>(b, std::move(d), bind, id);
     cb->start();
 }
 template <class T, class B>

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -141,7 +141,7 @@ makeAndExecuteAsyncWrite(
     B bind,
     std::string const& id)
 {
-    auto* cb = new WriteCallbackData<T,B>(b, std::move(d), bind, id);
+    auto* cb = new WriteCallbackData<T, B>(b, std::move(d), bind, id);
     cb->start();
 }
 template <class T, class B>


### PR DESCRIPTION
Clio doesn't build on Ubuntu/g++ because of failed template deduction. This PR contains the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cjcobb23/clio/89)
<!-- Reviewable:end -->
