### PR TITLE
add max connection to test

### DIFF
--- a/unittests/main.cpp
+++ b/unittests/main.cpp
@@ -45,6 +45,7 @@ TEST(BackendTest, Basic)
                     {"database", keyspace.c_str()},
                     {"password", "postgres"},
                     {"indexer_key_shift", 2},
+                    {"max_connections", 100},
                     {"threads", 8}}}}}};
             std::vector<boost::json::object> configs = {
                 cassandraConfig, postgresConfig};
@@ -1677,6 +1678,7 @@ TEST(Backend, CacheIntegration)
                     {"database", keyspace.c_str()},
                     {"password", "postgres"},
                     {"indexer_key_shift", 2},
+                    {"max_connections", 100},
                     {"threads", 8}}}}}};
             std::vector<boost::json::object> configs = {
                 cassandraConfig, postgresConfig};


### PR DESCRIPTION
Adds `max_connection: 100` to postgres configurations in unittests.

We were exceeding the default number of connections in postgres and that was causing the tests to halt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cjcobb23/clio/100)
<!-- Reviewable:end -->
