### PR TITLE
specify CMAKE_CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 
 project(clio VERSION 0.1.0)
 
+set(CMAKE_CXX_STANDARD 20)
+
 option(BUILD_TESTS "Build tests" TRUE)
 
 option(VERBOSE "Verbose build" TRUE)

--- a/src/rpc/handlers/Subscribe.cpp
+++ b/src/rpc/handlers/Subscribe.cpp
@@ -281,7 +281,7 @@ subscribeToBooks(
     std::shared_ptr<WsBase> session,
     SubscriptionManager& manager)
 {
-    for (auto const book : books)
+    for (auto const& book : books)
     {
         manager.subBook(book, session);
     }


### PR DESCRIPTION
Clio was complaining about `contains` for me... Adding `CMAKE_CXX_STANDARD` fixed it for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cjcobb23/clio/102)
<!-- Reviewable:end -->
