### PR TITLE
Quiet postgres

### DIFF
--- a/CMake/deps/Postgres.cmake
+++ b/CMake/deps/Postgres.cmake
@@ -9,7 +9,8 @@ ExternalProject_Add(postgres
     CONFIGURE_COMMAND ./configure --prefix ${POSTGRES_INSTALL_DIR} --without-readline --verbose
     BUILD_COMMAND ${CMAKE_COMMAND} -E env --unset=MAKELEVEL make VERBOSE=${CMAKE_VERBOSE_MAKEFILE} -j32
     BUILD_IN_SOURCE 1
-    INSTALL_COMMAND  ${CMAKE_COMMAND} -E env make install
+    INSTALL_COMMAND  ${CMAKE_COMMAND} -E env make -s --no-print-directory install
+    UPDATE_COMMAND ""
     BUILD_BYPRODUCTS
         ${POSTGRES_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}pq${CMAKE_STATIC_LIBRARY_SUFFIX}}
         ${POSTGRES_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}pgcommon${CMAKE_STATIC_LIBRARY_SUFFIX}}

--- a/CMake/settings.cmake
+++ b/CMake/settings.cmake
@@ -1,5 +1,1 @@
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing -Wall -Werror -Wno-dangling-else")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,8 @@ add_library(clio)
 target_compile_features(clio PUBLIC cxx_std_20)
 target_include_directories(clio PUBLIC src)
 
-
 include(FetchContent)
-if(${CMAKE_VERSION} VERSION_LESS "3.20.0")
-  include(ExternalProject)
-endif()
+include(ExternalProject)
 include(CMake/settings.cmake)
 include(CMake/deps/rippled.cmake)
 include(CMake/deps/Boost.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.16)
 
 project(clio VERSION 0.1.0)
 
-set(CMAKE_CXX_STANDARD 20)
-
 option(BUILD_TESTS "Build tests" TRUE)
 
 option(VERBOSE "Verbose build" TRUE)
@@ -13,6 +11,7 @@ if(VERBOSE)
 endif()
 
 add_library(clio)
+target_compile_features(clio PUBLIC cxx_std_20)
 target_include_directories(clio PUBLIC src)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(clio VERSION 0.1.0)
 


### PR DESCRIPTION
1. The new install that postgres does is noisy. This shuts it up
2. Moves the cxx standard setting to only libclio and targets that use it.
3. Specifically requires the CMake version that ships with Ubuntu 20.04.
4. Removes implicitly including ExternalProject

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cjcobb23/clio/107)
<!-- Reviewable:end -->
